### PR TITLE
Update clone.js with doc about deep copying arrays

### DIFF
--- a/src/function/arithmetic/round.js
+++ b/src/function/arithmetic/round.js
@@ -39,7 +39,7 @@ export const createRound = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    *    math.round(-4.2)             // returns number -4
    *    math.round(-4.7)             // returns number -5
    *    math.round(3.22, 1)          // returns number 3.2
-   *    math.round(3.88, 1)          // returns number 3.8
+   *    math.round(3.88, 1)          // returns number 3.9
    *    math.round(-4.21, 1)         // returns number -4.2
    *    math.round(-4.71, 1)         // returns number -4.7
    *    math.round(math.pi, 3)       // returns number 3.142

--- a/src/function/utils/clone.js
+++ b/src/function/utils/clone.js
@@ -6,7 +6,7 @@ const dependencies = ['typed']
 
 export const createClone = /* #__PURE__ */ factory(name, dependencies, ({ typed }) => {
   /**
-   * Clone an object. Arrays will be deep copied.
+   * Clone an object. Will make a deep copy of the data.
    *
    * Syntax:
    *
@@ -17,7 +17,7 @@ export const createClone = /* #__PURE__ */ factory(name, dependencies, ({ typed 
    *    math.clone(3.5)                   // returns number 3.5
    *    math.clone(math.complex('2-4i') // returns Complex 2 - 4i
    *    math.clone(math.unit(45, 'deg'))  // returns Unit 45 deg
-   *    math.clone([[1, 2], [3, 4]])      // returns Array [[1, 2], [3, 4]], as a deep copy
+   *    math.clone([[1, 2], [3, 4]])      // returns Array [[1, 2], [3, 4]]
    *    math.clone("hello world")         // returns string "hello world"
    *
    * @param {*} x   Object to be cloned

--- a/src/function/utils/clone.js
+++ b/src/function/utils/clone.js
@@ -6,7 +6,7 @@ const dependencies = ['typed']
 
 export const createClone = /* #__PURE__ */ factory(name, dependencies, ({ typed }) => {
   /**
-   * Clone an object.
+   * Clone an object. Arrays will be deep copied.
    *
    * Syntax:
    *
@@ -17,7 +17,7 @@ export const createClone = /* #__PURE__ */ factory(name, dependencies, ({ typed 
    *    math.clone(3.5)                   // returns number 3.5
    *    math.clone(math.complex('2-4i') // returns Complex 2 - 4i
    *    math.clone(math.unit(45, 'deg'))  // returns Unit 45 deg
-   *    math.clone([[1, 2], [3, 4]])      // returns Array [[1, 2], [3, 4]]
+   *    math.clone([[1, 2], [3, 4]])      // returns Array [[1, 2], [3, 4]], as a deep copy
    *    math.clone("hello world")         // returns string "hello world"
    *
    * @param {*} x   Object to be cloned


### PR DESCRIPTION
Since it was missing, and it is important documentation for anyone using math.clone for arrays of arrays (matrices). The deep copying was inferred from the test case, but it shouldn't have been necessary. Now it will hopefully be shown in the doc on the webpage, too.